### PR TITLE
Validating if the given token has the correct base64 format.

### DIFF
--- a/src/enki.token/TokenManager.cs
+++ b/src/enki.token/TokenManager.cs
@@ -63,7 +63,17 @@ namespace enki.token
                 return (_totp.getCodeString() == token);
             }
 
-            var decodedToken = Encoding.UTF8.GetString(Convert.FromBase64String(token));
+            byte[] tokenInBytes;
+            try
+            {
+                tokenInBytes = Convert.FromBase64String(token);
+            }
+            catch(FormatException)
+            {
+                return false;
+            }
+
+            var decodedToken = Encoding.UTF8.GetString(tokenInBytes);
             var splitedToken = decodedToken.Split('.');
             if (splitedToken.Length != 3) return false;
             var tokenCode = _totp.getCodeString(ulong.Parse(splitedToken[2]));

--- a/test/enki.token.tests/Tests.cs
+++ b/test/enki.token.tests/Tests.cs
@@ -1,6 +1,6 @@
-﻿using Xunit;
-using enki.totp;
+﻿using enki.totp;
 using System;
+using Xunit;
 
 namespace enki.token.tests
 {
@@ -57,9 +57,9 @@ namespace enki.token.tests
         [Fact]
         public void DeveGerarEValidarTokenComDataDeExpiracao()
         {
-           var manager = new TokenManager("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ");
-           var hash = manager.GetHashWithExpireOn(DateTime.UtcNow.AddMinutes(5));
-           Assert.True(manager.IsValidToken(hash));
+            var manager = new TokenManager("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ");
+            var hash = manager.GetHashWithExpireOn(DateTime.UtcNow.AddMinutes(5));
+            Assert.True(manager.IsValidToken(hash));
         }
 
         [Fact]
@@ -74,6 +74,17 @@ namespace enki.token.tests
             Assert.Equal(date.Day, recoveredDate.Day);
             Assert.Equal(date.Hour, recoveredDate.Hour);
             Assert.Equal(date.Minute, recoveredDate.Minute);
+        }
+
+        [Fact]
+        public void DeveValidarTokenComFormatoInvalido()
+        {
+            var token = "s_b_hotl.gif";
+            var manager = new TokenManager("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ");
+
+            var result = manager.IsValidToken(token);
+
+            Assert.False(result);
         }
     }
 }


### PR DESCRIPTION
If the token entered does not have a valid base64 format, it is returned false.